### PR TITLE
Improved data upload instructions for PQ SDK Test framework data

### DIFF
--- a/testframework/data/PQSDKTestFrameworkDataSchema.sql
+++ b/testframework/data/PQSDKTestFrameworkDataSchema.sql
@@ -1,3 +1,9 @@
+/*
+NOTE: 
+1) While uploading to the data source, all decimal values should have a scale of 2. That is, the number of digits after the decimal point should be 2. 
+2) All timestamp values should be uploaded to the datasouce in MM/DD/YYYY HH24:MI:SS format.
+*/
+
 CREATE TABLE NycTaxiGreen (
     RecordID int,
     VendorID int,
@@ -14,7 +20,7 @@ CREATE TABLE NycTaxiGreen (
     mta_tax double,
     tip_amount double,
     tolls_amount double,
-    improvement_surcharge string,
+    improvement_surcharge double,
     total_amount double,
     payment_type int,
     trip_type int,


### PR DESCRIPTION
## Changes:

1) Added notes for uploading decimal and timestamp values 
2) Changed `improvement_surcharge` field to be double instead of string type